### PR TITLE
Fix AMA spinner and disclaimer positioning

### DIFF
--- a/content/themes/dude/sass/views/_template-ama-base.scss
+++ b/content/themes/dude/sass/views/_template-ama-base.scss
@@ -394,10 +394,32 @@
       color: var(--color-faded);
       font-size: 15px;
 
-      @media (min-width: 550px) {
-        margin-left: 240px;
+      // Because the button has a different width on dark and light mode, these need to be adjusted
+      @media (min-width: 550px) and (prefers-color-scheme: dark) {
+        margin-left: 278px; // 208px (button) + 10px (space) + 50px (spinner) + 10px (space) = 278px
         margin-top: -37px;
         position: absolute;
+      }
+
+      @media (min-width: 550px) and (prefers-color-scheme: dark) {
+        margin-left: 247px;
+        margin-top: -37px;
+        position: absolute; // 177px + 10px + 50px + 10px = 247px
+      }
+    }
+
+    // Also let's move this here, as this also needs adjusting based on color scheme
+    .sending-question {
+      @media (prefers-color-scheme: dark) {
+        position: absolute;
+        margin-top: -52px;
+        margin-left: 218px; // Button is 208px wide, + 10px = 218px
+      }
+      
+      @media (prefers-color-scheme: dark) {
+        position: absolute;
+        margin-top: -52px;
+        margin-left: 187px; // Button is 177px wide, + 10px = 187px
       }
     }
 

--- a/content/themes/dude/template-ama-2023.php
+++ b/content/themes/dude/template-ama-2023.php
@@ -136,7 +136,7 @@ $questions = array_reverse( $questions );
             <label for="question" class="screen-reader-text-dude">Kysymyksesi</label>
             <textarea name="question" id="question" class="textarea medium" v-model="question" aria-required="true" aria-invalid="false" rows="10" cols="50" minlength="5" maxlength="1000" placeholder="Kirjoita tähän kysymyksesi..."></textarea>
             <input class="button button-large" type="submit" v-on:click="submitQuestion" value="Lähetä kysymys" :disabled="sendingQuestion"/>
-            <div class="sending-question hide-until-vue-loaded" v-if="sendingQuestion" style="position: absolute; margin-top: -52px; margin-left: 195px;">
+            <div class="sending-question hide-until-vue-loaded" v-if="sendingQuestion">
               <div class="spinner">
                 <svg version="1.1"
                   xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Fixes the position of the AMA submit spinner and disclaimer. It seems that the new website theme with the new buttons (rounded for light theme, sharp cornered ones for dark theme) has made the spinner a bit off position.

This change also moves the "sending-question" from the style attribute to SCSS.


**Before**
![image](https://github.com/digitoimistodude/dude/assets/29684625/87586371-2058-46e1-af64-ca7b9146a49f)
![image](https://github.com/digitoimistodude/dude/assets/29684625/882808cb-1bc4-4f1b-91d2-85f9ebbf3aca)

**After**
![image](https://github.com/digitoimistodude/dude/assets/29684625/bd93c2ab-cb1b-4111-9dfa-bb2ba3c9ac13)
![image](https://github.com/digitoimistodude/dude/assets/29684625/6879c179-a1f7-4f29-9c40-36ea3a21134c)

*Please note that these changes have not been tested properly, and but they should work. But no guarantees, as they were developed at 3AM.*
